### PR TITLE
Update d3 browser support reference URL

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -93,7 +93,7 @@
     %li <a href="https://github.com/masayuki0812/c3/releases/tag/0.1.42">v0.1.42</a><span class="gray">&nbsp;-&nbsp;2014-05-18</span>
 
   %h3 Browser Support
-  %p Because of the dependence on D3, C3 supports only modern browsers D3 supports. Please see <a href="https://github.com/mbostock/d3/wiki#browser-support">the description in D3</a>:
+  %p Because of the dependence on D3, C3 supports only modern browsers D3 supports. Please see <a href="https://github.com/mbostock/d3/wiki#browser--platform-support">the description in D3</a>.
 
   %h3 License
   %p MIT


### PR DESCRIPTION
The existing link was outdated!
