### PR TITLE
Added includes for theme-tomorrow.js and mode-javascript.js

### DIFF
--- a/source/_sample_editor.haml
+++ b/source/_sample_editor.haml
@@ -1,4 +1,6 @@
 = javascript_include_tag "ace/ace.js"
+= javascript_include_tag "ace/mode-javascript.js"
+= javascript_include_tag "ace/theme-tomorrow.js"
 :javascript
   var editor = ace.edit('#{type}-editor'),
       error  = document.getElementById('ace-error');


### PR DESCRIPTION
I noticed the ACE Editor syntax highlighting from #14 wasn't working due to these two files not being included. I've since done so.
