### PR TITLE
fix: disable command-L override, 

### DIFF
--- a/source/_sample_editor.haml
+++ b/source/_sample_editor.haml
@@ -21,3 +21,4 @@
 
   editor.setTheme("ace/theme/tomorrow");
   editor.getSession().setMode("ace/mode/#{type}");
+  editor.commands.removeCommand('gotoline') // Disables the override of Command-L


### PR DESCRIPTION
This remove 'gotoline' shortcut command of ace editor and stop overriding Command-L in example pages.

---
fix #39